### PR TITLE
Don't skip content-type header by default

### DIFF
--- a/src/sparp/sparp.py
+++ b/src/sparp/sparp.py
@@ -161,7 +161,6 @@ async def async_main(configs, source_queue, source_semaphore, sink_queue, shared
     )
     async with RetryClient(
             client_session=aiohttp.ClientSession(
-                skip_auto_headers=["Content-Type"],
                 trace_configs=[trace_config],
                 **aiohttp_client_session_kwargs
             ),


### PR DESCRIPTION
This PR removes the default keyword argument `skip_auto_headers=["Content-Type"]` from the session initialisation.
If `sparp` users really want to skip the header generation they can always pass it via the `aiohttp_client_session_kwargs`.

As discussed here:
https://github.com/fredo838/sparp/issues/4